### PR TITLE
refactor: Update git command in getDiff function

### DIFF
--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -14,7 +14,7 @@ export function checkGitRepository() {
 
 export function getDiff(maxDiffLength: number) {
   const diff = execSync(
-    "git diff --cached . ':(exclude)package-lock.json' ':(exclude)yarn.lock' ':(exclude)pnpm-lock.yaml'"
+    "git diff --cached . ':(exclude)package-lock.json' ':(exclude)yarn.lock' ':(exclude)pnpm-lock.yaml' ':(exclude)bun.lockb'"
   ).toString();
 
   if (!diff) {


### PR DESCRIPTION
Changes the git command in getDiff function to exclude 'bun.lock' file. This is to ensure that the diff output is not included when generating a commit message.